### PR TITLE
Modify the order of procedure for alert

### DIFF
--- a/doc_source/option-1.md
+++ b/doc_source/option-1.md
@@ -72,9 +72,9 @@ You now create a rule that says "When CloudWatch receives any event from aws\.me
 
 1. In **Topic**, choose the topic you created, for example, "MediaLive\_alert"\.
 
-1. Choose **Configure details**
-
 1. In **Configure input**, choose **Matched event**\.
+
+1. Choose **Configure details**
 
 1. Type a name and optional description, then choose **Create rule**\. 
 


### PR DESCRIPTION
*Issue #, if available:*
The order of creating a cloudwatch event for SNS alert is not correct now.

*Description of changes:*
Changed the order of steps. We have to "Configure input" before "configure details"

![image](https://user-images.githubusercontent.com/1647045/40596832-735a1562-6278-11e8-9f3f-124d81421363.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
